### PR TITLE
feat: ArticleDetailTemplate atom/moleculeへの切り出し

### DIFF
--- a/nari-note-frontend/src/components/molecules/ArticleAuthorInfo.tsx
+++ b/nari-note-frontend/src/components/molecules/ArticleAuthorInfo.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { UserAvatar } from '@/components/ui';
+
+interface ArticleAuthorInfoProps {
+  authorId: number;
+  authorName: string;
+  createdAt?: string;
+}
+
+/**
+ * ArticleAuthorInfo - Molecule Component
+ *
+ * 記事の著者情報（アバター・名前・投稿日時）を表示するコンポーネント
+ */
+export function ArticleAuthorInfo({ authorId, authorName, createdAt }: ArticleAuthorInfoProps) {
+  return (
+    <Link
+      href={`/users/${authorId}`}
+      className="flex items-center gap-3 hover:opacity-80 transition-opacity"
+    >
+      <UserAvatar username={authorName} size="md" />
+      <div>
+        <div className="font-medium text-brand-text">{authorName}</div>
+        <div className="text-sm text-gray-500">
+          {createdAt ? new Date(createdAt).toLocaleDateString('ja-JP') : ''}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/nari-note-frontend/src/components/molecules/ArticleTagList.tsx
+++ b/nari-note-frontend/src/components/molecules/ArticleTagList.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+interface ArticleTagListProps {
+  tags: string[];
+}
+
+/**
+ * ArticleTagList - Molecule Component
+ *
+ * 記事のタグ一覧をリンク付きで表示するコンポーネント
+ */
+export function ArticleTagList({ tags }: ArticleTagListProps) {
+  if (tags.length === 0) return null;
+
+  return (
+    <div className="flex gap-2 flex-wrap pt-6 border-t border-gray-200">
+      {tags.map((tag) => (
+        <Link
+          key={tag}
+          href={`/tags/${tag}`}
+          className="px-3 py-1 bg-brand-bg-light text-brand-text rounded-full text-sm hover:bg-brand-bg-gradient-to transition-colors"
+        >
+          #{tag}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/nari-note-frontend/src/components/molecules/CourseBreadcrumb.tsx
+++ b/nari-note-frontend/src/components/molecules/CourseBreadcrumb.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { BookOpen, ChevronRight } from 'lucide-react';
+
+interface CourseBreadcrumbProps {
+  courseId: number;
+  courseName: string;
+}
+
+/**
+ * CourseBreadcrumb - Molecule Component
+ *
+ * コースに属する記事のパンくずリストを表示するコンポーネント
+ */
+export function CourseBreadcrumb({ courseId, courseName }: CourseBreadcrumbProps) {
+  return (
+    <div className="mb-4 flex items-center gap-2 text-sm text-gray-600">
+      <BookOpen className="w-4 h-4" />
+      <Link
+        href={`/courses/${courseId}`}
+        className="hover:text-brand-primary hover:underline flex items-center gap-1"
+      >
+        {courseName}
+      </Link>
+      <ChevronRight className="w-4 h-4" />
+      <span className="text-gray-800 font-medium">この記事</span>
+    </div>
+  );
+}

--- a/nari-note-frontend/src/components/molecules/index.ts
+++ b/nari-note-frontend/src/components/molecules/index.ts
@@ -18,4 +18,6 @@ export { FormPageLayout } from './FormPageLayout';
 export { AuthPageLayout } from './AuthPageLayout';
 export { ShogiBoard } from './ShogiBoard';
 export { NarinoteMarkdown } from './NarinoteMarkdown';
-
+export { CourseBreadcrumb } from './CourseBreadcrumb';
+export { ArticleAuthorInfo } from './ArticleAuthorInfo';
+export { ArticleTagList } from './ArticleTagList';

--- a/nari-note-frontend/src/features/article/templates/ArticleDetailTemplate.tsx
+++ b/nari-note-frontend/src/features/article/templates/ArticleDetailTemplate.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
-import { LikeButton, UserAvatar, LoadingSpinner, ErrorMessage } from '@/components/ui';
-import { NarinoteMarkdown } from '@/components/molecules';
+import { LikeButton, LoadingSpinner, ErrorMessage } from '@/components/ui';
+import { NarinoteMarkdown, CourseBreadcrumb, ArticleAuthorInfo, ArticleTagList } from '@/components/molecules';
 import { CommentForm } from '../organisms/CommentForm';
 import { CommentList } from '../organisms/CommentList';
 import { Comment } from '@/types/comment';
 import { Button } from '@/components/ui/button';
-import { Pencil, BookOpen, ChevronRight } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { GetArticleContentResponse } from '@/lib/api/types';
 import { PageWithSidebar } from '@/features/global/organisms';
 
@@ -23,7 +23,7 @@ interface ArticleDetailTemplateProps {
 
 /**
  * ArticleDetailTemplate - Template Component
- * 
+ *
  * 記事詳細ページのUI構成とレイアウトを担当
  * Organism/Moleculeを組み合わせてレスポンシブなUIを構築
  */
@@ -65,21 +65,10 @@ export function ArticleDetailTemplate({
   return (
     <PageWithSidebar>
     <article className="bg-white rounded-lg shadow-lg p-8">
-      {/* Course breadcrumb - only show if article is part of a course */}
       {article.courseId && article.courseName && (
-        <div className="mb-4 flex items-center gap-2 text-sm text-gray-600">
-          <BookOpen className="w-4 h-4" />
-          <Link
-            href={`/courses/${article.courseId}`}
-            className="hover:text-brand-primary hover:underline flex items-center gap-1"
-          >
-            {article.courseName}
-          </Link>
-          <ChevronRight className="w-4 h-4" />
-          <span className="text-gray-800 font-medium">この記事</span>
-        </div>
+        <CourseBreadcrumb courseId={article.courseId} courseName={article.courseName} />
       )}
-      
+
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-4xl font-bold text-brand-text">
           {article.title}
@@ -96,20 +85,14 @@ export function ArticleDetailTemplate({
           </Link>
         )}
       </div>
-      
+
       <div className="flex items-center gap-6 mb-8 pb-6 border-b border-gray-200">
-        <Link href={`/users/${article.authorId}`} className="flex items-center gap-3 hover:opacity-80 transition-opacity">
-          <UserAvatar username={article.authorName || 'Unknown Author'} size="md" />
-          <div>
-            <div className="font-medium text-brand-text">
-              {article.authorName || 'Unknown Author'}
-            </div>
-            <div className="text-sm text-gray-500">
-              {article.createdAt ? new Date(article.createdAt).toLocaleDateString('ja-JP') : ''}
-            </div>
-          </div>
-        </Link>
-        
+        <ArticleAuthorInfo
+          authorId={article.authorId!}
+          authorName={article.authorName || 'Unknown Author'}
+          createdAt={article.createdAt}
+        />
+
         <div className="flex items-center gap-4 ml-auto">
           <LikeButton
             isLiked={article.isLiked || false}
@@ -122,23 +105,13 @@ export function ArticleDetailTemplate({
           </button>
         </div>
       </div>
-      
+
       <div className="prose prose-lg max-w-none mb-8 text-gray-800 leading-relaxed">
         <NarinoteMarkdown content={article.body || ''} />
       </div>
-      
+
       {article.tags && article.tags.length > 0 && (
-        <div className="flex gap-2 flex-wrap pt-6 border-t border-gray-200">
-          {article.tags.map((tag) => (
-            <Link
-              key={tag}
-              href={`/tags/${tag}`}
-              className="px-3 py-1 bg-brand-bg-light text-brand-text rounded-full text-sm hover:bg-brand-bg-gradient-to transition-colors"
-            >
-              #{tag}
-            </Link>
-          ))}
-        </div>
+        <ArticleTagList tags={article.tags} />
       )}
 
       {/* コメント一覧 */}


### PR DESCRIPTION
closes #314

## 変更内容

`ArticleDetailTemplate`内にインライン実装されていた要素をmoleculeコンポーネントとして切り出しました。

- `CourseBreadcrumb`: コースパンくずリスト
- `ArticleAuthorInfo`: 著者情報（アバター・名前・投稿日時）
- `ArticleTagList`: タグ一覧表示

Generated with [Claude Code](https://claude.ai/code)