### PR TITLE
Feat: SEOメタデータの実装 (#205)

### DIFF
--- a/nari-note-frontend/src/app/(with-layout)/articles/[id]/page.tsx
+++ b/nari-note-frontend/src/app/(with-layout)/articles/[id]/page.tsx
@@ -1,11 +1,38 @@
-'use client';
-
-import { useParams } from 'next/navigation';
+import type { Metadata } from 'next';
 import { ArticleDetailPage } from '@/features/article/pages';
+import { getArticleContent } from '@/lib/api/server';
 
-export default function ArticleDetailPageRoute() {
-  const params = useParams();
-  const articleId = Number(params.id);
+interface ArticlePageProps {
+  params: Promise<{ id: string }>;
+}
 
-  return <ArticleDetailPage articleId={articleId} />;
+export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
+  const { id } = await params;
+
+  try {
+    const article = await getArticleContent({ id: Number(id) });
+    const plainText = article.body.replace(/<[^>]+>/g, '');
+    const description = plainText.slice(0, 160);
+
+    return {
+      title: article.title,
+      description,
+      openGraph: {
+        type: 'article',
+        title: article.title,
+        description,
+        publishedTime: article.publishedAt,
+        authors: [article.authorName],
+        tags: article.tags,
+      },
+    };
+  } catch {
+    return {};
+  }
+}
+
+export default async function ArticleDetailPageRoute({ params }: ArticlePageProps) {
+  const { id } = await params;
+
+  return <ArticleDetailPage articleId={Number(id)} />;
 }

--- a/nari-note-frontend/src/app/(with-layout)/courses/[id]/page.tsx
+++ b/nari-note-frontend/src/app/(with-layout)/courses/[id]/page.tsx
@@ -1,11 +1,34 @@
-'use client';
-
-import { useParams } from 'next/navigation';
+import type { Metadata } from 'next';
 import { CourseDetailPage } from '@/features/course/pages';
+import { getCourseContent } from '@/lib/api/server';
 
-export default function CourseDetailPageRoute() {
-  const params = useParams();
-  const courseId = Number(params.id);
+interface CoursePageProps {
+  params: Promise<{ id: string }>;
+}
 
-  return <CourseDetailPage courseId={courseId} />;
+export async function generateMetadata({ params }: CoursePageProps): Promise<Metadata> {
+  const { id } = await params;
+
+  try {
+    const course = await getCourseContent({ id: Number(id) });
+    const description = `${course.userName}による将棋コース「${course.name}」。${course.articles.length}本の記事を収録。`;
+
+    return {
+      title: course.name,
+      description,
+      openGraph: {
+        type: 'article',
+        title: course.name,
+        description,
+      },
+    };
+  } catch {
+    return {};
+  }
+}
+
+export default async function CourseDetailPageRoute({ params }: CoursePageProps) {
+  const { id } = await params;
+
+  return <CourseDetailPage courseId={Number(id)} />;
 }

--- a/nari-note-frontend/src/app/(with-layout)/tags/[name]/page.tsx
+++ b/nari-note-frontend/src/app/(with-layout)/tags/[name]/page.tsx
@@ -1,11 +1,22 @@
+import type { Metadata } from 'next';
 import { TagArticleListPage } from '@/features/tag/pages';
 
 interface TagPageProps {
   params: Promise<{ name: string }>;
 }
 
+export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
+  const { name } = await params;
+  const decodedName = decodeURIComponent(name);
+
+  return {
+    title: `#${decodedName}`,
+    description: `「${decodedName}」タグの将棋記事一覧`,
+  };
+}
+
 export default async function TagPage({ params }: TagPageProps) {
   const { name } = await params;
-  
+
   return <TagArticleListPage tagName={name} />;
 }

--- a/nari-note-frontend/src/app/layout.tsx
+++ b/nari-note-frontend/src/app/layout.tsx
@@ -5,9 +5,32 @@ import { QueryProvider } from "@/lib/providers/QueryProvider";
 import { AuthProvider } from "@/lib/providers/AuthProvider";
 import { UnauthorizedProvider } from "@/lib/providers/UnauthorizedProvider";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://nari-note.com";
+
 export const metadata: Metadata = {
-  title: "将棋ブログ投稿サイト ～なりノート～",
-  description: "将棋の知識共有プラットフォーム\nあなたの将棋の知識を共有し、コミュニティと共に成長しましょう",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "将棋ブログ投稿サイト ～なりノート～",
+    template: "%s | なりノート",
+  },
+  description: "将棋の知識共有プラットフォーム。あなたの将棋の知識を共有し、コミュニティと共に成長しましょう。",
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    url: siteUrl,
+    siteName: "なりノート",
+    title: "将棋ブログ投稿サイト ～なりノート～",
+    description: "将棋の知識共有プラットフォーム。あなたの将棋の知識を共有し、コミュニティと共に成長しましょう。",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "将棋ブログ投稿サイト ～なりノート～",
+    description: "将棋の知識共有プラットフォーム。あなたの将棋の知識を共有し、コミュニティと共に成長しましょう。",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/nari-note-frontend/src/app/robots.ts
+++ b/nari-note-frontend/src/app/robots.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://nari-note.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/articles/drafts',
+          '/articles/my-articles',
+          '/articles/new',
+          '/articles/*/edit',
+          '/courses/new',
+          '/courses/my-courses',
+          '/settings/',
+          '/debug/',
+        ],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/nari-note-frontend/src/app/sitemap.ts
+++ b/nari-note-frontend/src/app/sitemap.ts
@@ -1,0 +1,37 @@
+import { MetadataRoute } from 'next';
+import { getArticles } from '@/lib/api/server';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://nari-note.com';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/search`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+  ];
+
+  try {
+    const { articles } = await getArticles({ limit: 1000, offset: 0 });
+    const articleRoutes: MetadataRoute.Sitemap = articles
+      .filter((a) => a.isPublished)
+      .map((article) => ({
+        url: `${siteUrl}/articles/${article.id}`,
+        lastModified: new Date(article.updatedAt),
+        changeFrequency: 'weekly' as const,
+        priority: 0.8,
+      }));
+
+    return [...staticRoutes, ...articleRoutes];
+  } catch {
+    return staticRoutes;
+  }
+}


### PR DESCRIPTION
closes #205

## 変更内容

- `layout.tsx`: metadataBase, OGP, Twitter Card, robots設定を追加
- `articles/[id]/page.tsx`: Server Componentに変換しgenerateMetadata追加
- `courses/[id]/page.tsx`: Server Componentに変換しgenerateMetadata追加
- `tags/[name]/page.tsx`: generateMetadata追加
- `users/[id]/page.tsx`: ベースメタデータをそのまま使用（変更なし）
- `sitemap.ts`: 動的サイトマップ生成
- `robots.ts`: robots.txt生成

Generated with [Claude Code](https://claude.ai/code)