### PR TITLE
Feat: パスワードのバリデーションを強化

### DIFF
--- a/nari-note-backend/Src/Application/Dto/Request/SignUpRequest.cs
+++ b/nari-note-backend/Src/Application/Dto/Request/SignUpRequest.cs
@@ -16,5 +16,8 @@ public class SignUpRequest
     [Required(ErrorMessage = "パスワードは必須です")]
     [MinLength(8, ErrorMessage = "パスワードは8文字以上で入力してください")]
     [MaxLength(255, ErrorMessage = "パスワードは255文字以内で入力してください")]
+    [RegularExpression(
+        @"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()\-_=+\[\]{};':""\\|,.<>\/?]).+$",
+        ErrorMessage = "パスワードは英大文字・英小文字・数字・記号をそれぞれ1文字以上含む必要があります")]
     public required string Password { get; set; }
 }

--- a/nari-note-frontend/src/features/auth/pages/SignUpPage.tsx
+++ b/nari-note-frontend/src/features/auth/pages/SignUpPage.tsx
@@ -57,7 +57,32 @@ export function SignUpPage() {
       setError('パスワードを入力してください');
       return;
     }
-    
+
+    if (password.length < 8) {
+      setError('パスワードは8文字以上で入力してください');
+      return;
+    }
+
+    if (!/[a-z]/.test(password)) {
+      setError('パスワードは英小文字（a-z）を1文字以上含む必要があります');
+      return;
+    }
+
+    if (!/[A-Z]/.test(password)) {
+      setError('パスワードは英大文字（A-Z）を1文字以上含む必要があります');
+      return;
+    }
+
+    if (!/\d/.test(password)) {
+      setError('パスワードは数字（0-9）を1文字以上含む必要があります');
+      return;
+    }
+
+    if (!/[!@#$%^&*()\-_=+\[\]{};':"\\|,.<>/?]/.test(password)) {
+      setError('パスワードは記号（!@#$%^&*等）を1文字以上含む必要があります');
+      return;
+    }
+
     if (password !== passwordConfirm) {
       setError('パスワードが一致しません');
       return;

--- a/nari-note-frontend/src/features/auth/templates/SignUpTemplate.tsx
+++ b/nari-note-frontend/src/features/auth/templates/SignUpTemplate.tsx
@@ -47,10 +47,10 @@ export function SignUpTemplate({
         
         <EmailField value={email} onChange={onEmailChange} />
         
-        <PasswordField 
-          value={password} 
+        <PasswordField
+          value={password}
           onChange={onPasswordChange}
-          helperText="8文字以上で入力してください"
+          helperText="8文字以上・英大文字・英小文字・数字・記号をそれぞれ含む必要があります"
         />
         
         <PasswordField


### PR DESCRIPTION
## 概要

脆弱なパスワードを許容しないようバリデーションルールを追加しました。

## 変更内容

- 英大文字（A-Z）を1文字以上
- 英小文字（a-z）を1文字以上
- 数字（0-9）を1文字以上
- 記号（!@#$%^&*等）を1文字以上

Closes #92

Generated with [Claude Code](https://claude.ai/code)