### PR TITLE
fix: 記事編集画面のテキスト入力エリアを拡大

### DIFF
--- a/nari-note-frontend/src/components/molecules/MarkdownEditor.tsx
+++ b/nari-note-frontend/src/components/molecules/MarkdownEditor.tsx
@@ -263,9 +263,9 @@ export function MarkdownEditor({
         </p>
       )}
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-2 gap-4 items-stretch">
         {/* Editor Input */}
-        <div className="relative">
+        <div className="relative flex flex-col">
           <textarea
             ref={textareaRef}
             id="markdown-editor"
@@ -276,7 +276,7 @@ export function MarkdownEditor({
               handleTab(e);
             }}
             placeholder={placeholder}
-            className="w-full min-h-[50vh] p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white font-mono text-sm resize-y"
+            className="w-full flex-1 min-h-[70vh] p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white font-mono text-sm resize-y"
           />
 
           {/* Command Menu */}
@@ -308,7 +308,7 @@ export function MarkdownEditor({
         </div>
 
         {/* Live Preview */}
-        <div className="border border-gray-300 rounded-lg p-4 bg-white overflow-y-auto min-h-[50vh]">
+        <div className="border border-gray-300 rounded-lg p-4 bg-white overflow-y-auto min-h-[70vh]">
           <div className="prose prose-sm max-w-none">
             <NarinoteMarkdown content={value || PREVIEW_PLACEHOLDER} />
           </div>


### PR DESCRIPTION
fixes #351

記事編集画面でテキスト入力エリアをプレビューと同じ高さに拡大しました。

Generated with [Claude Code](https://claude.ai/code)