### PR TITLE
ArticleCardのネストした<a>タグをstretched-linkパターンで修正

### DIFF
--- a/nari-note-frontend/src/components/molecules/ArticleCard.tsx
+++ b/nari-note-frontend/src/components/molecules/ArticleCard.tsx
@@ -28,10 +28,12 @@ export function ArticleCard({
   date,
 }: ArticleCardProps) {
   return (
-    <Link
-      href={`/articles/${id}`}
-      className="block bg-white rounded-lg p-5 border border-gray-200 hover:shadow-lg hover:border-brand-primary/30 transition-all duration-200"
-    >
+    <div className="relative bg-white rounded-lg p-5 border border-gray-200 hover:shadow-lg hover:border-brand-primary/30 transition-all duration-200">
+      <Link
+        href={`/articles/${id}`}
+        className="absolute inset-0"
+        aria-label={title}
+      />
       <div className="flex flex-col gap-3">
         <h3 className="text-lg font-bold text-gray-800">{title}</h3>
         <UserAvatarLink userId={authorId} username={author} size="sm" />
@@ -52,6 +54,6 @@ export function ArticleCard({
           <span>{date}</span>
         </div>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/nari-note-frontend/src/components/molecules/UserAvatarLink.tsx
+++ b/nari-note-frontend/src/components/molecules/UserAvatarLink.tsx
@@ -33,7 +33,7 @@ export function UserAvatarLink({
         <Link
           href={`/users/${userId}`}
           onClick={(e) => e.stopPropagation()}
-          className="hover:text-brand-primary hover:underline text-sm text-gray-600"
+          className="relative z-10 hover:text-brand-primary hover:underline text-sm text-gray-600"
         >
           {username}
         </Link>


### PR DESCRIPTION
Fixes #171

## 変更内容

- ArticleCardの外側`<Link>`を`<div className="relative ...">`に変更
- `<Link className="absolute inset-0">`を追加してstretched-linkパターンを実装
- UserAvatarLinkのユーザー名`<Link>`に`relative z-10`を追加

Generated with [Claude Code](https://claude.ai/code)