### PR TITLE
スマホ画面のHeaderを調整

### DIFF
--- a/nari-note-frontend/src/features/global/organisms/Header.tsx
+++ b/nari-note-frontend/src/features/global/organisms/Header.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/lib/providers/AuthProvider';
 import { useLogout } from '@/lib/api';
 import { HeaderLogo } from './HeaderLogo';
 import { HeaderNav } from './HeaderNav';
+import { HeaderNavMobile } from './HeaderNavMobile';
 import { HeaderUserMenu } from './HeaderUserMenu';
 import { HeaderAuthButtons } from './HeaderAuthButtons';
 
@@ -39,6 +40,7 @@ export function Header() {
       {/* Bottom row: Navigation menu with dark background */}
       <div className="bg-brand-text border-b border-brand-text-dark shadow-sm">
         <div className="w-11/12 mx-auto px-4 py-2.5 flex items-center justify-center relative">
+          {/* Desktop: centered navigation */}
           <HeaderNav />
 
           <div className="flex items-center gap-4 absolute right-4">
@@ -59,6 +61,9 @@ export function Header() {
             )}
           </div>
         </div>
+
+        {/* Mobile: horizontally scrollable navigation row */}
+        <HeaderNavMobile />
       </div>
     </header>
   );

--- a/nari-note-frontend/src/features/global/organisms/HeaderNavMobile.tsx
+++ b/nari-note-frontend/src/features/global/organisms/HeaderNavMobile.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+
+/**
+ * モバイル用ヘッダーナビゲーションコンポーネント
+ *
+ * スマホ画面でのみ表示される横スクロール対応のナビゲーションバーです。
+ */
+export function HeaderNavMobile() {
+  return (
+    <nav className="md:hidden overflow-x-auto border-t border-brand-text-dark">
+      <div className="flex items-center gap-8 px-4 py-2.5 w-max">
+        <Link
+          href="/"
+          className="text-white hover:text-brand-primary font-medium transition-colors text-sm whitespace-nowrap"
+          style={{ fontFamily: 'serif' }}
+        >
+          ホーム
+        </Link>
+        <Link
+          href="/search"
+          className="text-white hover:text-brand-primary transition-colors text-sm whitespace-nowrap"
+          style={{ fontFamily: 'serif' }}
+        >
+          記事を探す
+        </Link>
+        <Link
+          href="/articles/new"
+          className="text-white hover:text-brand-primary transition-colors text-sm whitespace-nowrap"
+          style={{ fontFamily: 'serif' }}
+        >
+          記事を投稿
+        </Link>
+        <Link
+          href="/courses/new"
+          className="text-white hover:text-brand-primary transition-colors text-sm whitespace-nowrap"
+          style={{ fontFamily: 'serif' }}
+        >
+          講座を作成
+        </Link>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## 概要

- スマホ画面でHeaderメニューを2段構成に変更
- ログイン系ボタンを1段目右側に配置
- ナビゲーション系を2段目に配置（横スクロール対応）

Closes #391

Generated with [Claude Code](https://claude.ai/code)