### PR TITLE
マイページのスマホ表示を修正

### DIFF
--- a/nari-note-frontend/src/features/user/organisms/ProfileCard.tsx
+++ b/nari-note-frontend/src/features/user/organisms/ProfileCard.tsx
@@ -27,28 +27,44 @@ export function ProfileCard({
   onFollowClick,
 }: ProfileCardProps) {
   return (
-    <div className="bg-white rounded-lg shadow p-6">
-      <div className="flex items-start gap-6">
+    <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+      <div className="flex items-start gap-4 sm:gap-6">
         <UserAvatar
           username={user.username || 'Unknown User'}
           size="xl"
         />
 
-        <div className="flex-1">
-          <h1 className="text-3xl font-bold text-brand-text mb-2">
-            {user.username || 'Unknown User'}
-          </h1>
-          <p className="text-gray-600 mb-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2 mb-1 sm:mb-2">
+            <h1 className="text-lg sm:text-3xl font-bold text-brand-text">
+              {user.username || 'Unknown User'}
+            </h1>
+            <div className="flex-shrink-0">
+              {isOwnProfile ? (
+                <Link href="/settings/profile">
+                  <Button variant="outline" size="sm">プロフィール編集</Button>
+                </Link>
+              ) : (
+                <FollowButton
+                  isFollowing={user.isFollowing || false}
+                  onClick={onFollowClick}
+                  disabled={isFollowPending}
+                />
+              )}
+            </div>
+          </div>
+
+          <p className="text-gray-600 text-sm mb-3 sm:mb-4">
             @{user.username || 'unknown'}
           </p>
 
           {user.bio && (
-            <p className="text-gray-700 mb-4">
+            <p className="text-gray-700 text-sm sm:text-base mb-3 sm:mb-4">
               {user.bio}
             </p>
           )}
 
-          <div className="flex gap-6 text-sm text-gray-600">
+          <div className="flex flex-wrap gap-4 sm:gap-6 text-sm text-gray-600">
             <button
               onClick={onArticlesClick}
               className="hover:opacity-70 transition-opacity cursor-pointer"
@@ -68,20 +84,6 @@ export function ProfileCard({
             />
           </div>
         </div>
-
-        {isOwnProfile ? (
-          <Link href="/settings/profile">
-            <Button variant="outline">
-              プロフィール編集
-            </Button>
-          </Link>
-        ) : (
-          <FollowButton
-            isFollowing={user.isFollowing || false}
-            onClick={onFollowClick}
-            disabled={isFollowPending}
-          />
-        )}
       </div>
     </div>
   );

--- a/nari-note-frontend/src/features/user/organisms/ProfileTabNav.tsx
+++ b/nari-note-frontend/src/features/user/organisms/ProfileTabNav.tsx
@@ -54,13 +54,13 @@ export function ProfileTabNav({
   return (
     <div className="bg-white rounded-lg shadow">
       <div className="border-b border-gray-200">
-        <nav className="flex gap-8 px-6">
+        <nav className="flex gap-6 sm:gap-8 px-4 sm:px-6 overflow-x-auto">
           {tabContext === 'content' ? (
             <>
               {/* コンテンツタブ（記事/いいね/フォロー中のタグ） */}
               <button
                 onClick={() => onTabChange('articles')}
-                className={`py-4 border-b-2 ${
+                className={`py-4 border-b-2 whitespace-nowrap flex-shrink-0 ${
                   activeTab === 'articles'
                     ? 'border-brand-primary text-brand-text font-medium'
                     : 'border-transparent text-gray-600 hover:text-brand-text'
@@ -70,7 +70,7 @@ export function ProfileTabNav({
               </button>
               <button
                 onClick={() => onTabChange('likes')}
-                className={`py-4 border-b-2 ${
+                className={`py-4 border-b-2 whitespace-nowrap flex-shrink-0 ${
                   activeTab === 'likes'
                     ? 'border-brand-primary text-brand-text font-medium'
                     : 'border-transparent text-gray-600 hover:text-brand-text'
@@ -80,7 +80,7 @@ export function ProfileTabNav({
               </button>
               <button
                 onClick={() => onTabChange('following-tags')}
-                className={`py-4 border-b-2 ${
+                className={`py-4 border-b-2 whitespace-nowrap flex-shrink-0 ${
                   activeTab === 'following-tags'
                     ? 'border-brand-primary text-brand-text font-medium'
                     : 'border-transparent text-gray-600 hover:text-brand-text'
@@ -94,7 +94,7 @@ export function ProfileTabNav({
               {/* フォロータブ（フォロワー/フォロー中） */}
               <button
                 onClick={() => onTabChange('followers')}
-                className={`py-4 border-b-2 ${
+                className={`py-4 border-b-2 whitespace-nowrap flex-shrink-0 ${
                   activeTab === 'followers'
                     ? 'border-brand-primary text-brand-text font-medium'
                     : 'border-transparent text-gray-600 hover:text-brand-text'
@@ -104,7 +104,7 @@ export function ProfileTabNav({
               </button>
               <button
                 onClick={() => onTabChange('followings')}
-                className={`py-4 border-b-2 ${
+                className={`py-4 border-b-2 whitespace-nowrap flex-shrink-0 ${
                   activeTab === 'followings'
                     ? 'border-brand-primary text-brand-text font-medium'
                     : 'border-transparent text-gray-600 hover:text-brand-text'
@@ -118,7 +118,7 @@ export function ProfileTabNav({
       </div>
 
       {/* タブコンテンツ */}
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         {activeTab === 'articles' && (
           <ArticleList
             articles={articlesData?.articles}


### PR DESCRIPTION
fixes #395

## 変更内容

- ProfileCard: アバター・情報・ボタンを3カラム横並びからアバター+情報エリアの2カラム構成に変更。ボタンを情報エリア内に移動しスマホでのオーバーフローを解消
- ProfileTabNav: タブナビをoverflow-x-autoでスクロール可能にしもーバイルでのタブ表示を修正

Generated with [Claude Code](https://claude.ai/code)