### PR TITLE
記事の保存エラーを修正

### DIFF
--- a/nari-note-backend/Migrations/20260424015101_ChangeKifuTextSize.Designer.cs
+++ b/nari-note-backend/Migrations/20260424015101_ChangeKifuTextSize.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NariNoteBackend.Infrastructure.Database;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NariNoteBackend.Migrations
 {
     [DbContext(typeof(NariNoteDbContext))]
-    partial class NariNoteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424015101_ChangeKifuTextSize")]
+    partial class ChangeKifuTextSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/nari-note-backend/Migrations/20260424015101_ChangeKifuTextSize.cs
+++ b/nari-note-backend/Migrations/20260424015101_ChangeKifuTextSize.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NariNoteBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeKifuTextSize : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "KifuText",
+                table: "Kifus",
+                type: "character varying(8192)",
+                maxLength: 8192,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(4096)",
+                oldMaxLength: 4096);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "KifuText",
+                table: "Kifus",
+                type: "character varying(4096)",
+                maxLength: 4096,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(8192)",
+                oldMaxLength: 8192);
+        }
+    }
+}

--- a/nari-note-backend/Src/Domain/Entity/Kifu.cs
+++ b/nari-note-backend/Src/Domain/Entity/Kifu.cs
@@ -16,7 +16,7 @@ public class Kifu : EntityBase
     public required string Name { get; set; }
 
     [Required]
-    [MaxLength(4096)]
+    [MaxLength(8192)]
     public required string KifuText { get; set; }
 
     [Required]

--- a/nari-note-frontend/src/features/article/pages/ArticleFormPage.tsx
+++ b/nari-note-frontend/src/features/article/pages/ArticleFormPage.tsx
@@ -52,8 +52,8 @@ export function ArticleFormPage({ articleId, mode = 'create', courseId }: Articl
       setIsPublishing(false);
     },
     onError: (error) => {
-      console.error('記事の投稿に失敗しました:', error);
-      setValidationError('記事の投稿に失敗しました。もう一度お試しください。');
+      console.error('記事の保存に失敗しました:', error);
+      setValidationError('記事の保存に失敗しました。もう一度お試しください。');
       setIsPublishing(false);
     },
   });
@@ -65,8 +65,8 @@ export function ArticleFormPage({ articleId, mode = 'create', courseId }: Articl
       setIsPublishing(false);
     },
     onError: (error) => {
-      console.error('記事の更新に失敗しました:', error);
-      setValidationError('記事の更新に失敗しました。もう一度お試しください。');
+      console.error('記事の保存に失敗しました:', error);
+      setValidationError('記事の保存に失敗しました。もう一度お試しください。');
       setIsPublishing(false);
     },
   });


### PR DESCRIPTION
棋譜テキストのカラムサイズが小さすぎたので調整